### PR TITLE
ignore intellij temp files by default

### DIFF
--- a/modd.go
+++ b/modd.go
@@ -41,6 +41,8 @@ var CommonExcludes = []string{
 	"**#",
 	"**.bak",
 	"**.swp",
+	"**.___jb_old___",
+	"**.___jb_bak___",
 
 	// Python
 	"**.py[cod]",


### PR DESCRIPTION
These are used by JetBrains' IntelliJ suite (IDEA, PyCharm, RubyMine, ...).