### PR TITLE
Fix formatting of error notification

### DIFF
--- a/prep.go
+++ b/prep.go
@@ -2,6 +2,7 @@ package modd
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 
 	"github.com/cortesi/modd/conf"
@@ -53,7 +54,7 @@ func RunProc(cmd, shellMethod string, log termlog.Stream) error {
 
 			mut.Lock()
 			defer mut.Unlock()
-			buff.WriteString(s + "\n")
+			fmt.Fprintf(buff, "%s\n", args...)
 		},
 	)
 	go logOutput(&wg, stdo, log.Say)


### PR DESCRIPTION
Growl notification from a failed prep step was incorrectly showing the formatting string instead of captured output:

<img width="310" alt="screen shot 2016-06-02 at 2 41 07 am" src="https://cloud.githubusercontent.com/assets/97163/15736162/beb155be-286b-11e6-8501-dd9b17bf3607.png">

Quick fix to properly display command output.