### PR TITLE
Add PowerShell Support

### DIFF
--- a/shell/shell.go
+++ b/shell/shell.go
@@ -8,9 +8,6 @@ import (
 	"github.com/google/shlex"
 )
 
-// Default Inteface to use if none provided.
-var Default = "bash"
-
 // Interface to the shell.
 type Interface interface {
 	// Name of the shell interface.
@@ -25,6 +22,7 @@ var shells = make(map[string]Interface)
 func init() {
 	register(&Exec{})
 	register(&Bash{})
+	register(&PowerShell{})
 }
 
 // Register a new shell interface.
@@ -100,4 +98,15 @@ func (b *Bash) Command(line string) (*exec.Cmd, error) {
 		return nil, err
 	}
 	return exec.Command(sh, "-c", line), nil
+}
+
+// Windows PowerShell
+type PowerShell struct{}
+
+func (r *PowerShell) Name() string {
+	return "powershell"
+}
+
+func (r *PowerShell) Command(line string) (*exec.Cmd, error) {
+	return exec.Command("powershell", "-Command", line), nil
 }

--- a/shell/shell_posix.go
+++ b/shell/shell_posix.go
@@ -1,0 +1,6 @@
+// +build  !windows
+
+package shell
+
+// Default Inteface to use if none provided.
+var Default = "bash"

--- a/shell/shell_windows.go
+++ b/shell/shell_windows.go
@@ -1,0 +1,6 @@
+// +build  windows
+
+package shell
+
+// Default Inteface to use if none provided.
+var Default = "powershell"


### PR DESCRIPTION
...and make it the default shell on Windows.
The behaviour of bash.exe (if present) is quite variable, and a user
that invokes modd from Windows itself does not expect that modd
'teleports' its commands into WSL or something alike. PowerShell is
*relatively* compatible with bash as least as it supports the very basic
unix commands such as `cd`.