### PR TITLE
Add mage_output_file.go to CommonExcludes

### DIFF
--- a/modd.go
+++ b/modd.go
@@ -43,6 +43,7 @@ var CommonExcludes = []string{
 	"**.swp",
 	"**.___jb_old___",
 	"**.___jb_bak___",
+	"**mage_output_file.go",
 
 	// Python
 	"**.py[cod]",


### PR DESCRIPTION
Hi @cortesi 

I'm running [Mage](https://magefile.org) targets with modd, which seems to use `mage_output_file.go` well beyond the lull period. This PR adds `mage_output_file.go` to CommonExcludes. Causes a lot of repetition in modd.conf otherwise.

More info at https://github.com/magefile/mage/issues/182.