### PR TITLE
add modd-notifier support

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,11 @@ systems. Modd uses the **notify-send** command to send notifications using
 libnotify. You'll need to use your system package manager to install
 **libnotify**.
 
+## ModdNotify
+
+Modd supports an external executable (or shell script) called **modd-notify**,
+which can be enabled with the `-n -t modd-notify` option. This allows an external
+script to be called for a custom notifier (ie: noti or others).
 
 # Colour output in process logs
 

--- a/cmd/modd/main.go
+++ b/cmd/modd/main.go
@@ -41,6 +41,10 @@ var doNotify = kingpin.Flag("notify", "Send stderr to system notification if com
 	Short('n').
 	Bool()
 
+var notifyType = kingpin.Flag("notifier", "Select the notifier").
+	Short('t').
+	String()
+
 var prep = kingpin.Flag("prep", "Run prep commands and exit").
 	Short('p').
 	Bool()
@@ -99,7 +103,7 @@ func main() {
 
 	notifiers := []notify.Notifier{}
 	if *doNotify {
-		n := notify.PlatformNotifier()
+		n := notify.PlatformNotifier(*notifyType)
 		if n == nil {
 			log.Shout("Could not find a desktop notifier")
 		} else {

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -52,12 +52,32 @@ func (LibnotifyNotifier) Push(title string, text string, iconPath string) {
 	go cmd.Run()
 }
 
+// ModdNotifier is a notifier for running shell commands
+type ModdNotifier struct {
+}
+
+// Push implements Notifier
+func (n ModdNotifier) Push(title string, text string, iconPath string) {
+	cmd := exec.Command(
+		"modd-notify", "-t", title, "-m", text,
+	)
+	go cmd.Run()
+}
+
+var notifiers = map[string]Notifier{
+	"growlnotify": &GrowlNotifier{},
+	"notify-send": &LibnotifyNotifier{},
+	"modd-notify": &ModdNotifier{},
+}
+
 // PlatformNotifier finds a notifier for this platform
-func PlatformNotifier() Notifier {
-	if hasExecutable("growlnotify") {
-		return &GrowlNotifier{}
-	} else if hasExecutable("notify-send") {
-		return &LibnotifyNotifier{}
+func PlatformNotifier(name string) Notifier {
+	n, ok := notifiers[name]
+	if !ok {
+		return nil
+	}
+	if hasExecutable(name) {
+		return n
 	}
 	return nil
 }


### PR DESCRIPTION
This PR changes modd to allow for `modd-notifier` support, which is simply an external custom program or shell script to notify the user. I would like to redirect notifications to [noti](https://github.com/variadico/noti) for push notifications. Below is a sample script in my path, enabled with: `modd -n -t modd-notify`

modd-notifier (for noti):
```sh
#!/bin/sh

title=""
message=""

while getopts ":t:m:" opt; do
  case ${opt} in
    t )
      title=$OPTARG
      ;;
    m )
      message=$OPTARG
      ;;
    \? ) echo "Usage: modd-notifier -t "title" -m "message"
      ;;
  esac
done

noti -t "$title" -m "$message"
```