### PR TITLE
Send os.Interrupt instead of os.Kill on ctrl+c

### DIFF
--- a/shell/shell.go
+++ b/shell/shell.go
@@ -157,7 +157,7 @@ func (e *Executor) Signal(sig os.Signal) error {
 }
 
 func (e *Executor) Stop() error {
-	return e.Signal(os.Kill)
+	return e.Signal(os.Interrupt)
 }
 
 func logOutput(wg *sync.WaitGroup, fp io.ReadCloser, out func(string, ...interface{})) {


### PR DESCRIPTION
We should let the daemon gracefully exit instead of killing it
on ctrl+c. If the user really wants it to die immediately they can hit
ctrl+\ or send a SIGKILL via the kill program. But it's not expected
behavior on ctrl+c.